### PR TITLE
CS-425 service filter tags, no colon in services and other locations,…

### DIFF
--- a/src/components/businesses/Business.js
+++ b/src/components/businesses/Business.js
@@ -21,7 +21,7 @@ class Business extends PureComponent {
 
   _renderContacts = subject => {
     return (
-      <div className="col-lg-4 col-md-4 col-xs-12 p-0 main-contact">
+      <div className="col-lg-5 col-md-5 col-xs-12 p-0 main-contact">
         <p className="business-title">{'Contact:'}</p>
         {isEmpty(subject.phones) ? '' : <h4>{subject.phones[0].number}</h4>}
         {isEmpty(subject.email) ? (
@@ -218,7 +218,7 @@ class Business extends PureComponent {
             </div>
             <hr />
             <p className="business-title col-lg-12 col-md-12 col-xs-12 p-0">
-              {'Services:'}
+              {'Services'}
             </p>
             {business.services.map(service => {
               return (
@@ -261,16 +261,13 @@ class Business extends PureComponent {
             {!isEmpty(other_locations) &&
               !isMobile && (
                 <div className="col-lg-12 col-md-12 col-xs-12 grid p-0">
-                  <hr />
-                  <div className="col-lg-12 col-md-12 col-xs-12 grid p-0">
-                    <div className="col-lg-6 col-md-6 col-xs-6 p-0 m-right-54">
-                      <p className="business-title">{'Other Locations:'}</p>
-                    </div>
-                    <div className="col-lg-4 col-md-4 col-xs-6 p-0">
-                      <p className="business-title">{'Contact:'}</p>
-                    </div>
-                    {this._renderOtherLocations(other_locations)}
+                  <div className="col-lg-6 col-md-6 col-xs-6 p-0 m-right-54">
+                    <p className="business-title">{'Other Locations'}</p>
                   </div>
+                  <div className="col-lg-4 col-md-4 col-xs-6 p-0">
+                    <p className="business-title">{'Contact:'}</p>
+                  </div>
+                  {this._renderOtherLocations(other_locations)}
                 </div>
               )}
           </div>

--- a/src/components/businesses/mobile/ResultPage.js
+++ b/src/components/businesses/mobile/ResultPage.js
@@ -62,6 +62,7 @@ class ResultPage extends Component {
           <TabPanel>
             <div className="map-container">
               <MapView
+                isMobile={this.props.isMobile}
                 locations={locations}
                 onBoundsChange={onBoundsChange}
                 highlightOrgCard={highlightOrgCard}
@@ -77,6 +78,7 @@ class ResultPage extends Component {
 ResultPage.PropTypes = {
   BusinessesList: PropTypes.arrayOf(PropTypes.object),
   highlightOrgCard: PropTypes.func.isRequired,
+  isMobile: PropTypes.bool.isRequired,
   locations: PropTypes.array,
   onBoundsChange: PropTypes.func,
   showLoading: PropTypes.bool,

--- a/src/components/filters/FilterByText.js
+++ b/src/components/filters/FilterByText.js
@@ -76,7 +76,7 @@ class FilterByText extends Component {
         className={
           isEmpty(filters)
             ? 'filter-label-container-hide'
-            : 'filter-label-container-show'
+            : 'filter-label-container-show text-bold'
         }
       >
         <TagsBox

--- a/src/components/filters/mobile/FilterByText.js
+++ b/src/components/filters/mobile/FilterByText.js
@@ -54,7 +54,7 @@ class FilterByTextMobile extends PureComponent {
         className={
           isEmpty(filters)
             ? 'filter-label-container-hide'
-            : 'filter-label-container-show'
+            : 'filter-label-container-show text-bold'
         }
       >
         <TagsBox

--- a/src/components/layouts/ContentMap.js
+++ b/src/components/layouts/ContentMap.js
@@ -134,6 +134,7 @@ class ContentMap extends Component {
     return (
       <ResultPage
         showLoading={this.props.showLoading}
+        isMobile={this.props.isMobile}
         BusinessesList={this.props.children}
         locations={locations}
         onBoundsChange={this.props.onBoundsChange}
@@ -179,6 +180,7 @@ class ContentMap extends Component {
       businesses,
       topBar,
       expanded,
+      isMobile,
     } = this.props;
     const {locations, organizations} = businesses;
     return (
@@ -198,6 +200,7 @@ class ContentMap extends Component {
             }
           >
             <MapView
+              isMobile={isMobile}
               locations={locations}
               onBoundsChange={onBoundsChange}
               highlightOrgCard={highlightOrgCard}
@@ -220,6 +223,7 @@ ContentMap.propTypes = {
   expandMap: PropTypes.func.isRequired,
   highlightOrgCard: PropTypes.func.isRequired,
   isMobile: PropTypes.bool.isRequired,
+  locations: PropTypes.array,
   onBoundsChange: PropTypes.func.isRequired,
   redoSearchInMap: PropTypes.func.isRequired,
   reduceMap: PropTypes.func.isRequired,

--- a/src/components/map-view/Main.js
+++ b/src/components/map-view/Main.js
@@ -8,47 +8,52 @@ class Main extends Component {
     super(props);
     this.state = {
       selected: '-1',
+      coordinates: {lat: 38.57, lng: -121.47},
     };
   }
   getCoordinates(business) {
     return business.coordinates;
   }
-  handleBoundsChange(e) {
+  handleBoundsChange = e => {
     this.props.onBoundsChange(e);
   }
-  _handleOnClick(e) {
-    this.setState({selected: e});
-  }
-  _handleCloseClick() {
+  _handleOnClick = (e, childProps) => {
+    this.setState({
+      selected: e,
+      coordinates: {
+        lat: childProps.lat,
+        lng: childProps.lng},
+    });
+  };
+  _handleCloseClick = () => {
     this.setState({selected: -1});
-  }
-  _handleChildMouseEnter(e) {
+  };
+  _handleChildMouseEnter = e => {
     this.props.highlightOrgCard(
       this.props.locations.find(x => String(x.id) === e).organization.id
     );
-  }
-  _handleChildMouseLeave() {
+  };
+  _handleChildMouseLeave = () => {
     this.props.highlightOrgCard(-1);
-  }
+  };
 
   render() {
     const {locations} = this.props;
     const firstBusiness = locations ? locations[0] : null;
-    const sacCoordinates = {lat: 38.57, lng: -121.47};
-    const map_options = {fullscreenControl: false};
+    const mapOptions = {fullscreenControl: false};
     const zoomLevel = 7;
     if (firstBusiness) {
       return (
         <GoogleMap
-          center={sacCoordinates}
+          center={this.state.coordinates}
           zoom={zoomLevel}
           hoverDistance={12}
-          onChange={e => this.handleBoundsChange(e)}
+          onChange={this.handleBoundsChange}
           resetBoundsOnResize={true}
-          options={map_options}
-          onChildMouseEnter={e => this._handleChildMouseEnter(e)}
-          onChildMouseLeave={() => this._handleChildMouseLeave()}
-          onChildClick={e => this._handleOnClick(e)}
+          options={mapOptions}
+          onChildMouseEnter={this._handleChildMouseEnter}
+          onChildMouseLeave={this._handleChildMouseLeave}
+          onChildClick={this._handleOnClick}
           bootstrapURLKeys={{
             key: process.env.GOOGLE_MAP_API_KEY,
           }}
@@ -62,7 +67,7 @@ class Main extends Component {
                 lng={lng}
                 organization={location.organization}
                 selected={this.state.selected === String(location.id)}
-                handleCloseClick={() => this._handleCloseClick()}
+                handleCloseClick={this._handleCloseClick}
               />
             );
           })}
@@ -71,11 +76,11 @@ class Main extends Component {
     }
     return (
       <GoogleMap
-        center={sacCoordinates}
+        center={this.state.coordinates}
         zoom={10}
         onChange={event => this.handleBoundsChange(event)}
         resetBoundsOnResize={true}
-        options={map_options}
+        options={mapOptions}
         bootstrapURLKeys={{
           key: process.env.GOOGLE_MAP_API_KEY,
         }}
@@ -86,6 +91,7 @@ class Main extends Component {
 
 Main.propTypes = {
   highlightOrgCard: PropTypes.func.isRequired,
+  isMobile: PropTypes.bool.isRequired,
   locations: PropTypes.arrayOf(PropTypes.object),
   onBoundsChange: PropTypes.func.isRequired,
 };

--- a/src/components/map-view/MapMarker.js
+++ b/src/components/map-view/MapMarker.js
@@ -38,7 +38,7 @@ class MapMarker extends Component {
   render() {
     const {$hover, selected, organization} = this.props;
     const orgInfoModal = (
-      <div id="orgModal" className="map_modal">
+      <div id="org-modal" className="map_modal">
         <div className="row between-xs top-xs map_modal_top">
           <a className="close-map-org" onClick={() => this._closeOrgInfo()}>
             <ClearIcon

--- a/src/components/shared/Chip.js
+++ b/src/components/shared/Chip.js
@@ -9,7 +9,7 @@ const Chip = ({canDelete, text, handleClick}) => (
     onClick={e => handleClick(e)}
     data-value={text}
   >
-    <span className="text text-bold">{text}</span>
+    <span className="text">{text}</span>
     {canDelete ? <span className="search-filter-icon">{'x'}</span> : null}
   </a>
 );

--- a/src/styles/components/businesses/businessList.css
+++ b/src/styles/components/businesses/businessList.css
@@ -1,12 +1,12 @@
 
 .businessList {
   z-index: 1;
-  transition: .3s ease all;
+  transition: .4s ease all;
   position: relative;
 }
 
 .businessList--reduced {
-  transition: .3s ease all;
+  transition: .4s ease all;
   position: relative;
 }
 

--- a/src/styles/components/businesses/map.css
+++ b/src/styles/components/businesses/map.css
@@ -1,6 +1,6 @@
 .map {
   position: relative;
-  transition: .3s ease all;
+  transition: .4s ease all;
   padding-right: 0px;
   float: right;
   width: 30%;
@@ -69,12 +69,17 @@
   height: 40px;
   width: 40px;
 }
-
+.business_block--expanded_bottom {
+  transition: visibility 0s, opacity 0.5s linear;
+  visibility: visible;
+  opacity: 1;
+}
 .map_modal {
+  transition: all 0.4s ease-in;
   text-align: center;
   width: 269px;
   bottom: 68px;
-  left: -156px;
+  left: -123px;
   margin-left: -90px;
   box-shadow: 0 0 2px 0 rgba(0,0,0,0.12), 0 2px 2px 0 rgba(12,0,51,0.1);
   background: white;
@@ -93,7 +98,7 @@
   display: block; /* reduce the damage in FF3.0 */
   position: absolute;
   bottom: -8px;
-  right: 15px;
+  right: 44%;
   width: 0;
   border-width: 8px 8px 0;
   border-style: solid;
@@ -109,11 +114,13 @@
   background-color: inherit;
 }
 .map_modal_logo {
+  transition: all 0.4s ease-in;
   width: 64px;
   height: 64px;
   display: inline-block;
 }
 .map_modal_title {
+  transition: all 0.4s ease-in;
   color: #000000;
   font-size: 16px;
   margin: 0;

--- a/src/styles/layout/_business.scss
+++ b/src/styles/layout/_business.scss
@@ -16,7 +16,7 @@
   }
 }
 .business {
-  transition: .3s ease all;
+  transition: .4s ease all;
   cursor: pointer;
   @media (max-width: 60em) {
     padding-left: 0px !important;
@@ -28,12 +28,12 @@
   cursor: pointer;
   .business-logo {
     width: 0px;
-    transition: .3s ease all;
+    transition: .4s ease all;
   }
 }
 .business-logo{
   width: 88px;
-  transition: .3s ease all;
+  transition: .4s ease all;
   @media (max-width: 60em) {
     width: 88px;
   }
@@ -49,7 +49,7 @@
     }
   }
   .full-information {
-    transition: .3s ease all;
+    transition: .4s ease all;
     .business-title {
       opacity: 0.5;
       font-size: 14px;
@@ -110,7 +110,7 @@
   }
   .social-icons {
     margin-bottom: 32px;
-    transition: .3s ease all;
+    transition: .4s ease all;
     &-hide {
       display: none;
     }
@@ -119,17 +119,12 @@
     }
   }
   .search-filter-label {
-    background-color: $white-color;
-    color: $primary-color;
-    border-radius: 21px;
-    padding: 0 4px;
-    font-size: 10px !important;
-    font-weight: bold !important;
+    padding: 4px 7px;
+    font-weight: 300;
+    font-size: 10px;
     margin-right: 4px;
-    white-space: nowrap;
-    display: inline-block;
-    margin-bottom: 2px !important;
-    cursor: default;
+    pointer-events: none;
+    cursor: auto;
   }
   @media (max-width: 60em) {
     overflow-y: scroll;

--- a/src/styles/layout/_container.scss
+++ b/src/styles/layout/_container.scss
@@ -135,6 +135,36 @@ $width: (
   max-width: 237px;
   width: 100%;
   height: 237px;
+  .map_modal_top {
+    padding: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 20px;
+  }
+  .map_modal {
+    width: 192px;
+    left: -10px;
+    bottom: 23px;
+    .map_modal_title {
+      font-size: 12px;
+      width: 114px;
+      padding: 5px;
+    }
+    .map_modal_logo {
+      width: 48px;
+      height: 48px;
+    }
+    hr {
+      display: none
+    }
+  }
+  .business_block--expanded_bottom {
+    visibility: hidden;
+    opacity: 0;
+    height: 0px;
+    padding: 0px;
+  }
 }
 
 .map-container-collapse {

--- a/src/styles/layout/_search-nav.scss
+++ b/src/styles/layout/_search-nav.scss
@@ -48,6 +48,12 @@
         position: absolute;
         right: 5px;
         top: -8px;
+        @media (max-width: 1300px) {
+          right: -7px;
+        }
+        @media (max-width: 1200px) {
+          right: 5px;
+        }
         @media (max-width: 60em) {
           top: 24%;
           left: 160px;
@@ -164,8 +170,7 @@
       color: $primary-color;
       border-radius: 21px;
       padding: 0 12px 0 9px;
-      font-size: 14px !important;
-      font-weight: bold !important;
+      font-size: 14px;
       margin-right: 5px;
       margin-bottom: 2px;
       white-space: nowrap;


### PR DESCRIPTION
## Description
- delete `:` from 'service` and `other locations`
- add `@media` for `search-by-text-icon`
- delete the class `text-bold` from the `chip` component and add `text-bold` to `filter-label-container-show`
- change `sacCoordinates` in the state and `onClick` change for the coordinates of the organization

## Motivation and Context
- No colon required after `Services`  and  `other locations`
- More spacing on the text bar in mid-size screens
- Service filter tags shouldn't be bolded
- center clicked location in the map

## Issue Link
https://fullstacklabs.atlassian.net/browse/CS-422
https://fullstacklabs.atlassian.net/browse/CS-423
https://fullstacklabs.atlassian.net/browse/CS-429
https://fullstacklabs.atlassian.net/browse/CS-425
https://fullstacklabs.atlassian.net/browse/CS-424

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed locally.
