### PR TITLE
CS-438 Total organization count shouldnt not be displayed when loadign

### DIFF
--- a/src/components/businesses/Main.js
+++ b/src/components/businesses/Main.js
@@ -112,6 +112,7 @@ class Main extends Component {
       <ContentMap
         locations={locations}
         isMobile={isMobile}
+        showLoading={this.props.showLoading}
         organizations={organizations}
         businessesMetadata={businessesMetadata}
         expanded={this.state.expanded}

--- a/src/components/businesses/mobile/ResultPage.js
+++ b/src/components/businesses/mobile/ResultPage.js
@@ -4,27 +4,33 @@ import MapView from '../../map-view/Main';
 import {Tab, Tabs, TabList, TabPanel} from 'react-tabs';
 
 class ResultPage extends Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
-      tabIndex: 0,
+      selectedTab: 0,
     };
   }
   render() {
-    const {tabIndex} = this.state;
+    const {selectedTab} = this.state;
+    const {showLoading} = this.props;
+    const {businessesMetadata: {totalOrganizations}} = this.props;
     return (
       <div>
         <Tabs
-          selectedIndex={tabIndex}
-          onSelect={tabIndex => this.setState({tabIndex})}
+          selectedIndex={selectedTab}
+          onSelect={selectedTab => this.setState({selectedTab})}
         >
           <TabList className="tabs-container">
             <span>
-              {this.props.TotalOrganizations} {'Resources Available'}
+              {showLoading
+                ? 'Loading Organizations'
+                : totalOrganizations == 1
+                  ? `${totalOrganizations} Organization Available`
+                  : `${totalOrganizations} Organizations Available`}
             </span>
             <Tab className="tab">
               <img src={
-                  this.state.tabIndex === 0 ? (
+                  selectedTab === 0 ? (
                     '../../static-data/images/ic_map_list-view-Green.png'
                   ) : (
                     '../../static-data/images/ic_map_list-view-Grey.png'
@@ -34,7 +40,7 @@ class ResultPage extends Component {
             </Tab>
             <Tab className="tab">
               <img src={
-                  this.state.tabIndex === 1 ? (
+                  selectedTab === 1 ? (
                     '../../static-data/images/ic_map_green.png'
                   ) : (
                     '../../static-data/images/ic_map_grey.png'
@@ -60,6 +66,7 @@ class ResultPage extends Component {
 }
 
 ResultPage.PropTypes = {
+  showLoading: PropTypes.bool,
   TotalOrganizations: PropTypes.array,
   BusinessesList: PropTypes.array,
   locations: PropTypes.array,

--- a/src/components/layouts/ContentMap.js
+++ b/src/components/layouts/ContentMap.js
@@ -92,10 +92,11 @@ class ContentMap extends Component {
   _renderResultPageMobile() {
     return (
       <ResultPage
+        showLoading={this.props.showLoading}
         BusinessesList={this.props.children}
         locations={this.props.locations}
         onBoundsChange={this.props.onBoundsChange}
-        TotalOrganizations={this.props.businessesMetadata.totalOrganizations}
+        businessesMetadata={this.props.businessesMetadata}
         highlightOrgCard={this.props.highlightOrgCard}
       />
     );


### PR DESCRIPTION
## Description
- add `loading organizations` while `showLoading=true` and when `organization is 1` show `1 organization`
- changes `tabIndex` for `selectedTab`

## Motivation and Context
- for mobile the number organizations while the organizations list is loading 

## Issue Link
https://fullstacklabs.atlassian.net/browse/CS-438