### PR TITLE
CS-433 Clicking anywhere on org cards should expand them, Change subheader text on homepage

### DIFF
--- a/src/components/businesses/Business.js
+++ b/src/components/businesses/Business.js
@@ -123,6 +123,7 @@ class Business extends PureComponent {
                 ? 'business col-lg-2 col-md-2 col-xs-2 p-0 m-bot-20'
                 : 'business business-img'
             }
+            onClick={this.toggleCard}
           >
             <img
               className="business-logo"
@@ -136,9 +137,11 @@ class Business extends PureComponent {
                 : 'business col-lg-12 col-md-12 col-xs-12 p-0'
             }
           >
-            <div className="preview-details-container">
-              <h3 className="title m-bot-8">{business.name}</h3>
-              <p className="preview-details">{business.description}</p>
+            <div className="business-details-container">
+              <div className="business-information" onClick={this.toggleCard}>
+                <h3 className="title m-bot-8">{business.name}</h3>
+                <p className="business-description">{business.description}</p>
+              </div>
               <div
                 className={
                   this.state.expanded

--- a/src/components/home/Main.js
+++ b/src/components/home/Main.js
@@ -25,22 +25,10 @@ const Main = ({items, getTextSearchResults}) => {
                 }
               </h2>
               <div className="desktop-devices text-thin">
-                <p>
-                  {
-                    'Over 650 resources to help your business grow est non commodo luctus,'
-                  }
-                  <br />
-                  {
-                    'nisi erat porttitor ligula, eget lacinia odio sem nec elit.'
-                  }
-                </p>
+                <p>{'Find local resources to help your business grow'}</p>
               </div>
               <div className="mobile-devices m-top-16 text-thin">
-                <p>
-                  {
-                    'Over 650 resources to help your business grow est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.'
-                  }
-                </p>
+                <p>{'Find local resources to help your business grow'}</p>
               </div>
               <div className="hero_inputContainer">
                 <BusinessesForm

--- a/src/styles/layout/_business.scss
+++ b/src/styles/layout/_business.scss
@@ -1,5 +1,7 @@
-.preview-details-container {
-  max-width: 95%;
+.business-details-container {
+  .business-information {
+    max-width: 95%;
+  }
   .website-icon {
     color: #fff;
     background-color: #2bd587;
@@ -15,6 +17,7 @@
 }
 .business {
   transition: .3s ease all;
+  cursor: pointer;
   @media (max-width: 60em) {
     padding-left: 0px !important;
   }
@@ -22,6 +25,7 @@
 .business-img {
   max-width: 0px;
   overflow: hidden;
+  cursor: pointer;
   .business-logo {
     width: 0px;
     transition: .3s ease all;
@@ -54,7 +58,7 @@
   &-collapse,
   &-expand {
     position: relative;
-    .preview-details {
+    .business-description {
       font-size: 14px;
       margin-top: 4px;
       line-height: 20px;
@@ -69,7 +73,7 @@
     }
   }
   &-collapse {
-    .preview-details {
+    .business-description {
       opacity: 0.5;
     }
     .full-information {
@@ -78,7 +82,7 @@
     }
   }
   &-expand {
-    .preview-details {
+    .business-description {
       opacity: 1;
     }
     .location {


### PR DESCRIPTION
## Description
- add `onClick={this.toggleCard}` to `className="business-information"` and to `className="business business-img"` to close and open the orgs card when their picture, name or description is clicked
-change subheader from `Over 650 resources to help your business grow est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.` to `Find local resources to help your business grow`

## Motivation and Context
- the organization cards should be easier to expand.
- the subheader text was changed


## Issue Link
https://fullstacklabs.atlassian.net/browse/CS-433
https://fullstacklabs.atlassian.net/browse/CS-434


