### PR TITLE
back to home button, fix social media outline and hide logo in the home page header for mobile

### DIFF
--- a/src/components/layouts/Main.js
+++ b/src/components/layouts/Main.js
@@ -4,11 +4,11 @@ import Header from '../shared/Header';
 import Footer from '../shared/Footer';
 import MobileFooter from '../shared/MobileFooter';
 
-const MainLayout = ({children, windowWidth}) => {
+const MainLayout = ({children, windowWidth, homePage}) => {
   const isMobile = windowWidth <= 960;
   return (
     <div>
-      <Header />
+      <Header homePage={homePage} />
       {children}
       {!isMobile && <Footer />}
       {isMobile && <MobileFooter />}
@@ -18,6 +18,7 @@ const MainLayout = ({children, windowWidth}) => {
 
 MainLayout.propTypes = {
   children: PropTypes.element,
+  homePage: PropTypes.bool.isRequired,
   windowWidth: PropTypes.number,
 };
 

--- a/src/components/shared/Header.js
+++ b/src/components/shared/Header.js
@@ -1,20 +1,27 @@
 import React from 'react';
+import {PropTypes} from 'prop-types';
 import {Link} from 'react-router';
 import BarsIcon from '../shared/barsIcon';
 import Logo from './Logo';
 
-const Header = () => {
+const Header = ({homePage}) => {
   return (
     <header className="headerContainer" htmlFor="header-dropdown">
       <div className="contentContainer header grid between-xs middle-xs text-thin">
         <div className="header_links-title">
-          <Link to="/">
-            <Logo />
-          </Link>
+          {!homePage && (
+            <Link to="/">
+              <Logo />
+            </Link>
+          )}
           <span className="header_title">{'Welcome to IO Ipsum'}</span>
-          <span className="header_leftLink text-regular">
-            {'Back to Lorem'}
-          </span>
+          {!homePage && (
+            <Link to="/">
+              <span className="header_leftLink text-regular">
+                {'Back to Home'}
+              </span>
+            </Link>
+          )}
         </div>
         <input id="header-dropdown" type="checkbox" name="dropdown" />
         <label htmlFor="header-dropdown" className="collapse-menu-icon">
@@ -34,6 +41,10 @@ const Header = () => {
       </div>
     </header>
   );
+};
+
+Header.propTypes = {
+  homePage: PropTypes.bool.isRequired,
 };
 
 export default Header;

--- a/src/containers/Businesses.js
+++ b/src/containers/Businesses.js
@@ -11,6 +11,7 @@ export class Businesses extends PureComponent {
   state = {
     width: window.innerWidth,
     showLoading: true,
+    homePage: false,
   };
 
   componentWillMount(_nextProps) {
@@ -168,7 +169,7 @@ export class Businesses extends PureComponent {
     const {width, showLoading} = this.state;
     const filterById = 'id' in params && true;
     return (
-      <MainLayout windowWidth={width}>
+      <MainLayout windowWidth={width} homePage={this.state.homePage} >
         <BusinessesPage
           businesses={businesses}
           windowWidth={width}

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -10,6 +10,7 @@ import * as actions from '../actions/business';
 export class Home extends Component {
   state = {
     width: window.innerWidth,
+    homePage: true,
   };
   componentWillMount(_nextProps) {
     window.addEventListener('resize', () => this.handleWindowSizeChange());
@@ -25,7 +26,7 @@ export class Home extends Component {
   };
   render() {
     return (
-      <MainLayout windowWidth={this.state.width}>
+      <MainLayout windowWidth={this.state.width} homePage={this.state.homePage}>
         <section>
           <HomeView
             items={this.props.items}

--- a/src/styles/layout/_business.scss
+++ b/src/styles/layout/_business.scss
@@ -13,6 +13,7 @@
   .social-icon {
     display: inline-block;
     height: 18px;
+    outline: 0;
   }
 }
 .business {

--- a/src/tests/components/shared/header.spec.js
+++ b/src/tests/components/shared/header.spec.js
@@ -16,9 +16,9 @@ describe('<Header />', () => {
       expect(wrapper.find('nav').length).toEqual(1);
     });
 
-    it('Render 4 links in the nav bar', () => {
+    it('Render 5 links in the nav bar', () => {
       const wrapper = shallow(<Header />);
-      expect(wrapper.find(Link).length).toEqual(4);
+      expect(wrapper.find(Link).length).toEqual(5);
     });
 
     it('Must have a link to contact-us page', () => {
@@ -43,15 +43,15 @@ describe('<Header />', () => {
       ).toBe(true);
     });
 
-    it('Must have a link to terms-of-use page', () => {
+    it('Must have a link to back-to-Home page', () => {
       const wrapper = shallow(<Header />);
       expect(
         wrapper.contains(
-          <Link className="header_link" to="/terms-of-use">
-            {'Terms of Use'}
+          <Link className="header_leftLink" to="/">
+            {'Back To Home'}
           </Link>
         )
-      ).toBe(true);
+      ).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Description
- add `this.state.homePage` in the containers
- add `outline: 0` to `.social-icon`

## Motivation and Context
- hide `Back to Home` in the home page, and for mobile: hide the logo in the header of the home page
- remove the outline when an icon is focus

## Issue Link
https://fullstacklabs.atlassian.net/browse/CS-452
https://fullstacklabs.atlassian.net/browse/CS-454

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed locally.
