### PR TITLE
CS-468 fix modal with map expanded and fix filter by a organization from the home page

### DIFF
--- a/src/components/filters/FilterByText.js
+++ b/src/components/filters/FilterByText.js
@@ -10,8 +10,14 @@ class FilterByText extends Component {
     inputOnFocus: false,
     showDropdown: false,
     searchText: '',
-    filterById: this.props.filterById && true,
   };
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.organizations.length !== this.props.organizations.length) {
+      nextProps.filterById && !isEmpty(nextProps.organizations)
+        ? this.setState({searchText: nextProps.organizations[0].name})
+        : this.setState({searchText: ''})
+    }
+  }
   deleteFilter = e => {
     const filter = e.currentTarget.getAttribute('data-value');
     this.props.handleOnChangeFilterOptions('category', filter, true);
@@ -30,15 +36,13 @@ class FilterByText extends Component {
     this.setState({
       showDropdown: false,
       searchText: '',
-      filterById: false,
       inputOnFocus: false,
     });
     this.props.handleClickOnClearAllFilters();
   };
-
   handleKeyPress = event => {
     const value = event.target.value;
-    this.setState({searchText: value, showDropdown: true, filterById: false});
+    this.setState({searchText: value, showDropdown: true});
     this.props.getTextSearchResults(value);
     if (isEmpty(value)) {
       this.setState({showDropdown: false});
@@ -132,8 +136,7 @@ class FilterByText extends Component {
   }
 
   render() {
-    const {appliedFilters, organizations} = this.props;
-    const [organization] = organizations;
+    const {appliedFilters, filterById} = this.props;
     return (
       <div className="col-md-12 col-xs-12 text-xs-margin filterTextContainer no-padding">
         <div className="grid search-text-form p-bot-16">
@@ -165,29 +168,19 @@ class FilterByText extends Component {
             <input
               type="text"
               className="search-by-text text-thin"
-              value={
-                this.state.filterById === true &&
-                isEmpty(appliedFilters) &&
-                !isEmpty(organizations)
-                  ? organization.name
-                  : this.state.searchText
-              }
+              value={this.state.searchText}
               onChange={e => this.handleKeyPress(e)}
               onClick={() => this.handleInputClicked()}
               placeholder="Search by Resource Name"
               style={
-                this.state.inputOnFocus ||
-                this.state.searchText ||
-                (this.state.filterById && isEmpty(appliedFilters))
+                this.state.inputOnFocus || this.state.searchText || filterById
                   ? {opacity: 1}
                   : {opacity: 0}
               }
             />
             <a
               style={
-                this.state.inputOnFocus ||
-                this.state.searchText ||
-                (this.state.filterById && isEmpty(appliedFilters))
+                this.state.inputOnFocus || this.state.searchText || filterById
                   ? {opacity: 0}
                   : {opacity: 1}
               }

--- a/src/styles/components/businesses/map.css
+++ b/src/styles/components/businesses/map.css
@@ -79,7 +79,7 @@
   text-align: center;
   width: 269px;
   bottom: 68px;
-  left: -123px;
+  left: -53px;
   margin-left: -90px;
   box-shadow: 0 0 2px 0 rgba(0,0,0,0.12), 0 2px 2px 0 rgba(12,0,51,0.1);
   background: white;

--- a/src/styles/layout/_search-nav.scss
+++ b/src/styles/layout/_search-nav.scss
@@ -26,7 +26,6 @@
     .search-by-text {
       display: inline-block;
       width: 87%;
-      transition: all 0.2s ease-in;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;


### PR DESCRIPTION
## Description
- remove `filterById` from the state
- add a `componentWillReceiveProps ` to set `this.state.searchText` when a organization was selected from the home page
- remove the transition from `search-by-text`
- change the position of the modal when the map is expanded 

## Motivation and Context
-  when a organization was selected from the homePage, the name of the organization selected should show in the search by text input in the result page
- the transition of the `searchByText` input was looking bad 
- the modal wasn't center with the location icon

## Issue Link
https://fullstacklabs.atlassian.net/browse/CS-468